### PR TITLE
HTTPS para todos los recursos del checkout

### DIFF
--- a/view/frontend/web/template/payment/openpay-offline.html
+++ b/view/frontend/web/template/payment/openpay-offline.html
@@ -24,22 +24,22 @@
         
         <div class="items check payable">            
             <h3 style="border-bottom: 1px solid #cccccc; padding-bottom: 15px;">Pago en efectivo en tiendas de conveniencia</h3>            
-            <img src="http://s28.postimg.org/duko0g6z1/stores.png" alt="" style="max-width: 100%;" />
+            <img src="https://s28.postimg.org/duko0g6z1/stores.png" alt="" style="max-width: 100%;" />
             <p>
                 <a href="http://www.openpay.mx/tiendas-de-conveniencia.html" target="_blank">Consulta las tiendas afiliadas</a>
             </p>           
             <h3 style="margin-top: 25px; margin-bottom: 20px;">Pasos para tu pago por tienda</h3>
             <div style="overflow: hidden;">                
                 <div style="width: 30%; float: left; text-align: center; padding-left: 1.5%; padding-right: 1.5%;">
-                    <img src="http://s14.postimg.org/wt10fdulp/step1.png" alt="" style="max-width: 100%;" />
+                    <img src="https://s14.postimg.org/wt10fdulp/step1.png" alt="" style="max-width: 100%;" />
                     <p style="padding: 3px;">Haz clic en el botón "Generar ficha de pago", donde tu compra quedará en espera de que realices tu pago.</p>
                 </div>    
                 <div style="width: 30%; float: left; text-align: center; padding-left: 1.5%; padding-right: 1.5%;">
-                    <img src="http://s28.postimg.org/azv09o2tl/step_store.png" alt="" style="max-width: 100%;" />
+                    <img src="https://s28.postimg.org/azv09o2tl/step_store.png" alt="" style="max-width: 100%;" />
                     <p style="padding: 3px;">Imprime tu recibo, llévalo a tu tienda de conveniencia más cercana y realiza el pago.</p>
                 </div>    
                 <div style="width: 30%; float: left; text-align: center; padding-left: 1.5%; padding-right: 1.5%;">
-                    <img src="http://s13.postimg.org/6c2yov3g3/step3.png" alt="" style="max-width: 100%;" />
+                    <img src="https://s13.postimg.org/6c2yov3g3/step3.png" alt="" style="max-width: 100%;" />
                     <p style="padding: 3px;">Inmediatamente después de recibir tu pago te enviaremos un correo electrónico con la confirmación de pago.</p>
                 </div>    
             </div>


### PR DESCRIPTION
Es indispensable usar HTTPS en el checkout para evitar advertencias de certificado SSL. Al hardcodear HTTP el explorador identifica recursos no seguros advirtiendo al usuario que el sitio no es del todo seguro.