### PR TITLE
Compatibilidad con Magento 2.4.7

### DIFF
--- a/Mail/Message.php
+++ b/Mail/Message.php
@@ -13,10 +13,10 @@
 
 namespace Openpay\Stores\Mail;
 
-use Zend\Mime\Mime;
-use Zend\Mime\PartFactory;
-use Zend\Mail\MessageFactory as MailMessageFactory;
-use Zend\Mime\MessageFactory as MimeMessageFactory;
+use Laminas\Mime\Mime;
+use Laminas\Mime\PartFactory;
+use Laminas\Mail\MessageFactory as MailMessageFactory;
+use Lminas\Mime\MessageFactory as MimeMessageFactory;
 
 class Message implements \Magento\Framework\Mail\MailMessageInterface {
 

--- a/Mail/Template/TransportBuilder.php
+++ b/Mail/Template/TransportBuilder.php
@@ -19,8 +19,8 @@ use Magento\Framework\Mail\Template\SenderResolverInterface;
 use Magento\Framework\Mail\TransportInterfaceFactory;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Phrase;
-use Zend\Mime\Mime;
-use Zend\Mime\PartFactory;
+use Laminas\Mime\Mime;
+use Laminas\Mime\PartFactory;
 
 class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
 {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,7 +17,7 @@
                 <label>Openpay (Pago en tiendas)</label>
                 <comment>
                     <![CDATA[
-                    <p>Version: 4.2.1</p>
+                    <p>Version: 4.2.2</p>
                     <a href="http://openpay.mx/" target="_blank">Clic aquí para registrar una cuenta con Openpay</a>
                     ]]>
                 </comment>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Openpay_Stores" setup_version="4.2.1">
+    <module name="Openpay_Stores" setup_version="4.2.2">
         <sequence>            
             <module name="Magento_Sales" />
             <module name="Magento_Checkout" />            


### PR DESCRIPTION
/* Control de Cambios */
Plugin: openpay-stores
Version: 4.2.2
Developer: gerardo.mendez@openpay.mx 
Type issue: [feature]
Country: Mexico, Colombia, Peru
Description: Support for 2.4.7 Magento version
UH: ES6-1826