### PR TITLE
Hotfix/es6 2038 guardado configuraciones multisite

### DIFF
--- a/Controller/Index/Webhook.php
+++ b/Controller/Index/Webhook.php
@@ -64,9 +64,15 @@ class Webhook extends \Magento\Framework\App\Action\Action implements CsrfAwareA
                 $charge = $openpay->charges->get($json->transaction->id);
             }
 
-            $this->logger->debug('#webhook', array('trx_id' => $json->transaction->id, 'status' => $charge->status));        
+            $this->logger->debug('#webhook', array('trx_id' => $json->transaction->id, 'status' => $charge->status));
+            
+            $this->logger->debug("#Webhook.openpay_stores json_input - " . json_encode($json));
+            if( (isset($json->type) && $json->type == "verification") || empty($json) || json_encode($json) == "{}"){
+                header('HTTP/1.1 200 OK');
+                return;
+            }
 
-            if (isset($json->type) && ($json->transaction->method == 'store' || $json->transaction->method == 'bank_account')) {
+            if ($json->transaction->method == 'store' || $json->transaction->method == 'bank_account') {
                 $order = $this->_objectManager->create('Magento\Sales\Model\Order');            
                 $order->loadByAttribute('ext_order_id', $charge->id);
 

--- a/Model/Utils/Currency.php
+++ b/Model/Utils/Currency.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Openpay\Stores\Model\Utils;
+
+use \Magento\Store\Model\StoreManagerInterface;
+
+class Currency 
+{
+    /**
+     * @var string
+     */
+    protected $currentCurrency;
+    
+    public function __construct(StoreManagerInterface $storeManager) {
+        $this->currentCurrency = $storeManager->getStore()->getCurrentCurrency()->getCode();
+    }
+
+
+     /**
+     * Return an array of currencies supported by country code
+     *
+     * @param string $countryCode
+     * @return array
+     */
+    public function getSupportedCurrenciesByCountryCode(string $countryCode) : array {
+        $currencies = ['USD'];
+        $countryCode = strtoupper($countryCode);
+        switch ($countryCode) {
+            case 'MX':
+                $currencies[] = 'MXN';
+                return $currencies;
+            case 'CO':
+                $currencies[] = 'COP';
+                return $currencies;
+            case 'PE':
+                $currencies[] = 'PEN';
+                return $currencies;
+            default:
+                break;
+        }
+    }
+
+     /**
+     * Return a true when the current currency configurated is supported, false otherwise
+     *
+     * @param array $countryCode
+     * @return array
+     */
+    public function isSupportedCurrentCurrency (array $supportedCurrencies) : bool {
+        return in_array($this->currentCurrency, $supportedCurrencies);
+    }
+
+    /**
+     * Return the current currency
+     * 
+     * @return string
+     */
+    public function getCurrentCurrency () : string {
+        return $this->currentCurrency;
+    }
+}

--- a/Observer/MerchantInfo.php
+++ b/Observer/MerchantInfo.php
@@ -1,0 +1,53 @@
+<?php
+/** 
+ * @category    Payments
+ * @package     Openpay_Stores
+ * @author      Antonio Silvan
+ * @copyright   Openpay (http://openpay.mx)
+ * @license     http://www.apache.org/licenses/LICENSE-2.0  Apache License Version 2.0
+ */
+
+namespace Openpay\Stores\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Message\ManagerInterface;
+use Openpay\Stores\Model\Payment as Config;
+
+/**
+ * Class MerchantInfo
+ */
+class MerchantInfo implements ObserverInterface
+{
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var ManagerInterface
+     */
+    protected $messageManager;
+
+    /**
+     * @param Config $config
+     * @param ManagerInterface $messageManager
+     */
+    public function __construct(
+    Config $config, ManagerInterface $messageManager
+    ) {
+        $this->config = $config;
+        $this->messageManager = $messageManager;
+    }
+
+    /**
+     * Create Webhook
+     *
+     * @param Observer $observer          
+     */
+    public function execute(Observer $observer) {
+        return $this->config->validateSettings();
+    }
+
+}

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -12,6 +12,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">    
     <event name="admin_system_config_changed_section_payment">
+        <observer name="openpaystores_observer_check_configcurrency" instance="Openpay\Stores\Observer\MerchantInfo"/>
         <observer name="openpaystores_observer_check_config" instance="Openpay\Stores\Observer\CreateWebhook"/>
     </event>
 </config>


### PR DESCRIPTION
Plugin: openpay-magento2-stores
Version: 4.2.3
Developer: joseantonio.silvan@openpay.mx
Description: Se valida si esta activado el main website en tiendas multisite para que permita guardar configuraciones de credencial en tiendas hijas.
HU: ES6-2038